### PR TITLE
【ポートフォリオ実装】20200423

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -33,8 +33,8 @@ export default {
 }
 </script>
 
-<style>
-@import url(http://fonts.googleapis.com/earlyaccess/notosansjp.css);
+<style scoped>
+@import url(//fonts.googleapis.com/earlyaccess/notosansjapanese.css);
 
 #App {
   font-family: 'Noto Sans JP', sans-serif;


### PR DESCRIPTION
# レビュー観点
CDNで引っ張ってきていたNoto SansがWeb Appにすると引っ張ってこれなかったのでURLを変更しました。
# 変更内容／作業内容
 - [ ] App.vue内でCDNとしてインポートしていたフォントのURLを変更しました。